### PR TITLE
Add HbA1c converter calculator

### DIFF
--- a/calculators/hba1c_converter.py
+++ b/calculators/hba1c_converter.py
@@ -1,0 +1,188 @@
+"""
+# HbA1c Converter
+
+## 📂 Configuration (TOML-style in docstring)
+
+[inputs]
+- name: value
+  type: number
+  required: true
+  min: 0.0
+  max: 20.0
+  description: HbA1c value to convert
+
+- name: input_unit
+  type: string
+  enum: ["percent", "mmol_mol"]
+  required: true
+  description: Unit of the input value (percent or mmol_mol)
+
+## 📂 Output (TOML-style)
+
+[result]
+  type: number
+  description: Converted HbA1c value (rounded to 1 decimal)
+
+[result_unit]
+  type: string
+  description: Unit of the result value
+
+[input_value]
+  type: number
+  description: Original input value
+
+[input_unit]
+  type: string
+  description: Unit of the input value
+
+[working]
+  type: string
+  description: Step-by-step calculation
+
+[interpretation]
+  type: string
+  description: Clinical interpretation of HbA1c level
+
+[reference]
+  type: string
+  default: "IFCC/DCCT standardization"
+
+[metadata]
+  type: object
+  fields:
+    timestamp: string (ISO8601)
+    version: string (e.g., "1.0")
+    calculator_name: string
+
+## 📂 Validation Rules
+- Value must be > 0 and ≤ 20 for percentage
+- Value must be > 0 and ≤ 200 for mmol/mol
+- input_unit must be one of: percent, mmol_mol
+
+## 📂 Usage (CLI or API)
+
+CLI: 
+  calc hba1c_converter --value 7.5 --input-unit percent
+
+API:
+  POST /calculate
+  {
+    "calculator": "hba1c_converter",
+    "params": {
+      "value": 7.5,
+      "input_unit": "percent"
+    }
+  }
+
+## 📂 Conversion Formula
+- From % to mmol/mol: mmol/mol = (% - 2.15) × 10.929
+- From mmol/mol to %: % = (mmol/mol / 10.929) + 2.15
+
+## 📂 Output Example
+{
+  "result": 58.5,
+  "result_unit": "mmol/mol",
+  "input_value": 7.5,
+  "input_unit": "percent",
+  "working": "HbA1c 7.5% → (7.5 - 2.15) × 10.929 = 58.5 mmol/mol",
+  "interpretation": "Pre-diabetes range (42-47 mmol/mol or 6.0-6.4%)",
+  "reference": "IFCC/DCCT standardization",
+  "metadata": {
+    "timestamp": "2025-12-14T10:00:00Z",
+    "version": "1.0",
+    "calculator_name": "hba1c_converter"
+  }
+}
+
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field, root_validator
+
+from core.metadata import build_metadata
+
+
+class HbA1cRequest(BaseModel):
+    value: float = Field(..., gt=0)
+    input_unit: Literal["percent", "mmol_mol"]
+
+    @root_validator
+    def validate_ranges(cls, values):
+        unit = values.get("input_unit")
+        val = values.get("value")
+        
+        if unit == "percent":
+            if val is not None and not (0 < val <= 20):
+                raise ValueError("HbA1c percentage must be in (0, 20]")
+        elif unit == "mmol_mol":
+            if val is not None and not (0 < val <= 200):
+                raise ValueError("HbA1c mmol/mol must be in (0, 200]")
+        else:
+            raise ValueError("input_unit must be one of: percent, mmol_mol")
+        
+        return values
+
+
+class HbA1cResponse(BaseModel):
+    result: float
+    result_unit: str
+    input_value: float
+    input_unit: str
+    working: str
+    interpretation: str
+    reference: str = "IFCC/DCCT standardization"
+    metadata: dict
+
+
+def _interpret_hba1c(mmol_mol_value: float) -> str:
+    """Provide clinical interpretation based on mmol/mol value."""
+    if mmol_mol_value < 42:
+        return "Normal range (below 42 mmol/mol or 6.0%)"
+    elif mmol_mol_value < 48:
+        return "Pre-diabetes range (42-47 mmol/mol or 6.0-6.4%)"
+    elif mmol_mol_value < 53:
+        return "Diabetes diagnosis threshold (48-52 mmol/mol or 6.5-6.9%)"
+    elif mmol_mol_value < 75:
+        return "Suboptimal control (53-74 mmol/mol or 7.0-8.9%)"
+    else:
+        return "Poor control (≥75 mmol/mol or ≥9.0%)"
+
+
+def calculate(params: HbA1cRequest | dict) -> HbA1cResponse:
+    """Convert HbA1c between percentage and mmol/mol.
+
+    Accepts either a HbA1cRequest or a plain dict (which will be validated).
+    
+    Conversion formulas:
+    - % to mmol/mol: (% - 2.15) × 10.929
+    - mmol/mol to %: (mmol/mol / 10.929) + 2.15
+    """
+    req = params if isinstance(params, HbA1cRequest) else HbA1cRequest(**params)
+    
+    if req.input_unit == "percent":
+        # Convert from percentage to mmol/mol
+        result = round((req.value - 2.15) * 10.929, 1)
+        result_unit = "mmol/mol"
+        working = f"HbA1c {req.value}% → ({req.value} - 2.15) × 10.929 = {result} mmol/mol"
+        mmol_mol_for_interp = result
+    else:
+        # Convert from mmol/mol to percentage
+        result = round((req.value / 10.929) + 2.15, 1)
+        result_unit = "percent"
+        working = f"HbA1c {req.value} mmol/mol → ({req.value} / 10.929) + 2.15 = {result}%"
+        mmol_mol_for_interp = req.value
+    
+    interpretation = _interpret_hba1c(mmol_mol_for_interp)
+    
+    return HbA1cResponse(
+        result=result,
+        result_unit=result_unit,
+        input_value=req.value,
+        input_unit=req.input_unit,
+        working=working,
+        interpretation=interpretation,
+        metadata=build_metadata("hba1c_converter"),
+    )

--- a/tests/test_hba1c_converter.py
+++ b/tests/test_hba1c_converter.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import math
+
+from calculators.hba1c_converter import HbA1cRequest, calculate
+
+
+def test_hba1c_percent_to_mmol_mol():
+    """Test conversion from percentage to mmol/mol."""
+    resp = calculate({"value": 7.5, "input_unit": "percent"})
+    # (7.5 - 2.15) × 10.929 = 58.5
+    assert abs(resp.result - 58.5) < 0.1
+    assert resp.result_unit == "mmol/mol"
+    assert resp.input_value == 7.5
+    assert resp.input_unit == "percent"
+    assert resp.metadata["calculator_name"] == "hba1c_converter"
+
+
+def test_hba1c_mmol_mol_to_percent():
+    """Test conversion from mmol/mol to percentage."""
+    resp = calculate({"value": 58.5, "input_unit": "mmol_mol"})
+    # (58.5 / 10.929) + 2.15 = 7.5
+    assert abs(resp.result - 7.5) < 0.1
+    assert resp.result_unit == "percent"
+    assert resp.input_value == 58.5
+    assert resp.input_unit == "mmol_mol"
+
+
+def test_hba1c_round_trip():
+    """Test that converting back and forth preserves the value."""
+    # Start with 6.5% (diabetes threshold)
+    resp1 = calculate({"value": 6.5, "input_unit": "percent"})
+    mmol_mol_result = resp1.result
+    
+    # Convert back to percentage
+    resp2 = calculate({"value": mmol_mol_result, "input_unit": "mmol_mol"})
+    assert abs(resp2.result - 6.5) < 0.1
+
+
+def test_hba1c_normal_range():
+    """Test normal range interpretation."""
+    resp = calculate({"value": 5.5, "input_unit": "percent"})
+    assert "Normal range" in resp.interpretation
+
+
+def test_hba1c_diabetes_range():
+    """Test diabetes diagnosis threshold interpretation."""
+    resp = calculate({"value": 48, "input_unit": "mmol_mol"})
+    assert "Diabetes" in resp.interpretation
+
+
+def test_invalid_percentage_range():
+    """Test that invalid percentage values are rejected."""
+    try:
+        calculate({"value": 25, "input_unit": "percent"})
+        assert False, "Should have raised ValueError"
+    except Exception as e:
+        assert "percentage must be in" in str(e)
+
+
+def test_invalid_mmol_mol_range():
+    """Test that invalid mmol/mol values are rejected."""
+    try:
+        calculate({"value": 250, "input_unit": "mmol_mol"})
+        assert False, "Should have raised ValueError"
+    except Exception as e:
+        assert "mmol/mol must be in" in str(e)
+
+
+def test_hba1c_working_field():
+    """Test that working field shows the calculation."""
+    resp = calculate({"value": 7.0, "input_unit": "percent"})
+    assert "7.0" in resp.working
+    assert "10.929" in resp.working


### PR DESCRIPTION
- Implements bidirectional conversion between HbA1c percentage and mmol/mol
- Includes conversion formulas: (% - 2.15) × 10.929 and reverse
- Provides clinical interpretation ranges (normal, pre-diabetes, diabetes, etc.)
- Full validation and error handling with range checks
- Comprehensive test suite with 8 passing tests
- Follows project standardization with TOML-style docstrings
- Integrates with CLI, API, and web forms