### PR TITLE
Fix: Documentation loading in GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -28,6 +28,11 @@ jobs:
             - name: Setup Pages
               uses: actions/configure-pages@v4
 
+            - name: Copy docs to site
+              run: |
+                  mkdir -p ./site/docs
+                  cp -r ./docs/* ./site/docs/
+
             - name: Upload artifact
               uses: actions/upload-pages-artifact@v3
               with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .env
+
+# Site docs are generated from /docs during deployment
+site/docs/
+

--- a/site/docs.html
+++ b/site/docs.html
@@ -205,9 +205,13 @@
     const docsIndex = [
       { title: 'Overview', file: 'index.md', id: 'index' },
       { title: 'Project Overview', file: 'overview.md', id: 'overview' },
+      { title: 'Setup and Usage', file: 'setup.md', id: 'setup' },
       { title: 'Development Guide', file: 'development.md', id: 'development' },
       { title: 'API Reference', file: 'api-reference.md', id: 'api-reference' },
       { title: 'Calculator Specifications', file: 'calculator-specs.md', id: 'calculator-specs' },
+      { title: 'Calculator Generator', file: 'calculator-generator.md', id: 'calculator-generator' },
+      { title: 'PR Automation Workflow', file: 'pr-automation-workflow.md', id: 'pr-automation-workflow' },
+      { title: 'Maintenance', file: 'maintenance.md', id: 'maintenance' },
       { title: 'RCPCH Brand Colors', file: 'colors.md', id: 'colors' },
     ];
 
@@ -247,7 +251,7 @@
       content.innerHTML = '<div class="flex justify-center p-8"><span class="loading loading-spinner loading-lg text-primary"></span></div>';
 
       try {
-        const response = await fetch(`../docs/${doc.file}`);
+        const response = await fetch(`./docs/${doc.file}`);
         if (!response.ok) throw new Error('Failed to load documentation');
         
         const markdown = await response.text();


### PR DESCRIPTION
## Issue
After merging the calculator generator PR, documentation is no longer loading on GitHub Pages with error:
`Error: Failed to load documentation at window.loadDoc (docs.html:251:33)`

## Root Cause
1. **Missing docs in deployment**: GitHub Pages workflow only deploys the `site/` folder, but docs.html was trying to fetch from `../docs/` which doesn't exist in the deployment
2. **Incomplete docs index**: Several new documentation files (setup.md, calculator-generator.md, pr-automation-workflow.md, maintenance.md) were not included in the `docsIndex` array

## Changes
- ✅ Updated GitHub Actions workflow to copy docs folder into site/docs during deployment
- ✅ Fixed fetch path from `../docs/` to `./docs/` to match deployment structure
- ✅ Added all missing documentation files to the docsIndex array
- ✅ Added site/docs/ to .gitignore (generated during deployment)

## Testing
- Tested locally with http-server - all documentation files load correctly
- Changes ensure docs will be available when deployed to GitHub Pages