### PR TITLE
Fix: Generator working field must be dictionary not string

### DIFF
--- a/site/generator.html
+++ b/site/generator.html
@@ -190,7 +190,7 @@
                   </label>
                   <textarea id="calcWorking" class="textarea textarea-bordered h-20 font-mono text-sm" placeholder="BMI = weight / height² = [result]" required></textarea>
                   <label class="label">
-                    <span class="label-text-alt text-xs">Use variable names and [result] placeholder. Example: BMI = weight / height² = [result]</span>
+                    <span class="label-text-alt text-xs">Use variable names and [result] placeholder. Will be stored as {"description": "..."}. Example: BMI = weight / height² = [result]</span>
                   </label>
                 </div>
 
@@ -638,7 +638,8 @@ Interpretation: BMI is [result] kg/m²</code></pre>
           logic += constantLines.join('; ') + '; ';
         }
         logic += `result = ${result}; `;
-        logic += `working = ${workingFString}; `;
+        // Working must be a dictionary for CalculationResponse
+        logic += `working = {"description": ${workingFString}}; `;
         logic += `interpretation = ${interpretationFString}`;
 
         let toml = `[calculator]\n`;


### PR DESCRIPTION
## Problem
The calculator generator was creating the `working` field as a string:
```python
working = 'BMI = weight / height² = [result]'
```

But `CalculationResponse` expects `working` to be `dict[str, Any]`, causing this validation error:
```
pydantic.error_wrappers.ValidationError: 1 validation error for CalculationResponse
working
  value is not a valid dict (type=type_error.dict)
```

## Solution
Updated `site/generator.html` to wrap the working text in a dictionary:
```python
working = {"description": "BMI = weight / height² = [result]"}
```

Also updated the help text to clarify this format for users.

## Testing
This should fix the validation error seen in the Glasgow Coma Score calculator submission (PR from `calculator/glasgow_coma_score` branch).

## Files Changed
- `site/generator.html` - Fixed logic generation to use dictionary format for working field