### PR TITLE
Fix: Generator formats long Field definitions for Black compliance

### DIFF
--- a/core/generator.py
+++ b/core/generator.py
@@ -259,7 +259,7 @@ def generate_calculator_code(spec: dict[str, Any]) -> str:
 
         # Build field definition - use multiline if it would be too long
         single_line = f"    {field_name}: {field_type} = Field({', '.join(field_args)})"
-        
+
         if len(single_line) > 88:
             # Break into multiple lines
             request_class.append(f"    {field_name}: {field_type} = Field(")

--- a/core/generator.py
+++ b/core/generator.py
@@ -257,8 +257,20 @@ def generate_calculator_code(spec: dict[str, Any]) -> str:
         if field_desc:
             field_args.append(f'description="{field_desc}"')
 
-        field_def = f"    {field_name}: {field_type} = Field({', '.join(field_args)})"
-        request_class.append(field_def)
+        # Build field definition - use multiline if it would be too long
+        single_line = f"    {field_name}: {field_type} = Field({', '.join(field_args)})"
+        
+        if len(single_line) > 88:
+            # Break into multiple lines
+            request_class.append(f"    {field_name}: {field_type} = Field(")
+            for i, arg in enumerate(field_args):
+                if i < len(field_args) - 1:
+                    request_class.append(f"        {arg},")
+                else:
+                    request_class.append(f"        {arg}")
+            request_class.append("    )")
+        else:
+            request_class.append(single_line)
 
     # Build calculate function
     calculate_func = [


### PR DESCRIPTION
## Problem
Generated calculators with long field descriptions fail Black formatting checks because lines exceed 88 characters:

```python
eyes: float = Field(..., ge=1, le=4, description="E4 spontaneous eye opening E3 eye opening to voice E2 eye opening to pain E1 no eye opening 0 Not possible to perform")
# Line too long! Black will complain
```

## Solution
Updated `core/generator.py` to detect when Field definitions would exceed 88 characters and break them into multiple lines:

```python
eyes: float = Field(
    ...,
    ge=1,
    le=4,
    description="E4 spontaneous eye opening E3 eye opening to voice..."
)
```

## Implementation
- Checks if single-line Field definition would be > 88 chars
- If too long, breaks into multiline format with proper indentation
- Each argument on its own line for readability
- Maintains Black/isort/ruff compliance

## Testing
This should fix the formatting warnings in the Glasgow Coma Score calculator.

## Files Changed
- `core/generator.py` - Updated Field generation logic