### PR TITLE
Add local testing script for calculator generation

### DIFF
--- a/docs/calculator-generator.md
+++ b/docs/calculator-generator.md
@@ -180,6 +180,68 @@ Check your Ollama service is accessible:
 curl ${OLLAMA_BASE_URL}/api/tags
 ```
 
+## Local Testing
+
+Before submitting a calculator via PR, you can test it locally using the `s/test-generator` script. This validates that the generated code passes all checks (Black, isort, Ruff, pytest).
+
+### Usage
+
+1. Create a TOML specification file:
+```toml
+[calculator]
+name = "my_calculator"
+description = "My Calculator"
+reference = "Reference citation"
+logic = "result = input1 + input2"
+
+[[inputs]]
+name = "input1"
+type = "number"
+description = "First input"
+required = true
+min = 0
+max = 100
+```
+
+2. Run the test script:
+```bash
+./s/test-generator my_calculator.toml
+```
+
+3. The script will:
+   - Generate calculator and test code
+   - Run Black formatter
+   - Run isort import sorter
+   - Run Ruff linter
+   - Run pytest
+   - Report any issues
+
+4. If all checks pass, you'll see:
+```
+✅ All checks passed!
+
+Files created:
+  - calculators/my_calculator.py
+  - tests/test_my_calculator.py
+
+To clean up test files, run:
+  rm calculators/my_calculator.py tests/test_my_calculator.py
+```
+
+### Note on Long Descriptions
+
+Black formatter allows long string literals in function arguments. If you see very long description strings in `Field()` definitions, this is intentional and compliant with Black's formatting rules. The code will pass all checks.
+
+Example of correct formatting:
+```python
+my_field: float = Field(
+    ...,
+    ge=0,
+    le=100,
+    description="This is a very long description that exceeds 88 characters but is allowed by Black when inside function arguments",
+)
+```
+
 ### GitHub CLI Not Authenticated
 
 Run:

--- a/s/test-generator
+++ b/s/test-generator
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Test script for validating generated calculator code
+# Usage: ./s/test-generator <toml_spec_file>
+
+set -e
+
+if [ -z "$1" ]; then
+  echo "Usage: ./s/test-generator <toml_spec_file>"
+  echo "Example: ./s/test-generator /tmp/my_calculator.toml"
+  exit 1
+fi
+
+SPEC_FILE="$1"
+
+if [ ! -f "$SPEC_FILE" ]; then
+  echo "Error: Spec file '$SPEC_FILE' not found"
+  exit 1
+fi
+
+echo "🔍 Testing calculator generation from: $SPEC_FILE"
+echo ""
+
+# Read spec file
+SPEC=$(cat "$SPEC_FILE")
+
+# Generate calculator using Docker
+echo "📝 Generating calculator code..."
+CALC_NAME=$(docker-compose run --rm api python << PYTHON
+from core.generator import generate_calculator
+import sys
+
+spec = """$SPEC"""
+
+try:
+    result = generate_calculator(spec)
+    
+    if not result.is_valid:
+        print("❌ Generation failed:", file=sys.stderr)
+        for error in result.validation_errors:
+            print(f"  - {error.field}: {error.message}", file=sys.stderr)
+        sys.exit(1)
+    
+    # Write files
+    calc_file = f"calculators/{result.name}.py"
+    test_file = f"tests/test_{result.name}.py"
+    
+    with open(calc_file, 'w') as f:
+        f.write(result.python_code)
+    
+    with open(test_file, 'w') as f:
+        f.write(result.test_code)
+    
+    print(f"✅ Generated:", file=sys.stderr)
+    print(f"   - {calc_file}", file=sys.stderr)
+    print(f"   - {test_file}", file=sys.stderr)
+    print("", file=sys.stderr)
+    
+    # Print name to stdout for capture
+    print(result.name)
+        
+except Exception as e:
+    print(f"❌ Error: {e}", file=sys.stderr)
+    sys.exit(1)
+PYTHON
+)
+
+echo "🎨 Running Black formatter..."
+docker-compose run --rm api black calculators/${CALC_NAME}.py tests/test_${CALC_NAME}.py
+
+echo ""
+echo "✨ Running isort..."
+docker-compose run --rm api isort calculators/${CALC_NAME}.py tests/test_${CALC_NAME}.py
+
+echo ""
+echo "🔍 Running Ruff linter..."
+docker-compose run --rm api ruff check calculators/${CALC_NAME}.py tests/test_${CALC_NAME}.py
+
+echo ""
+echo "🧪 Running tests..."
+docker-compose run --rm api pytest tests/test_${CALC_NAME}.py -v
+
+echo ""
+echo "✅ All checks passed!"
+echo ""
+echo "Files created:"
+echo "  - calculators/${CALC_NAME}.py"
+echo "  - tests/test_${CALC_NAME}.py"
+echo ""
+echo "To clean up test files, run:"
+echo "  rm calculators/${CALC_NAME}.py tests/test_${CALC_NAME}.py"


### PR DESCRIPTION
## Changes

- **New Tool**: `s/test-generator` script for local validation of generated calculators
- **Documentation**: Updated `docs/calculator-generator.md` with local testing instructions

## Purpose

Provides developers a way to test calculator generation locally before submitting PRs via the web interface. This catches formatting or test failures early.

## How It Works

```bash
./s/test-generator my_calculator.toml
```

The script:
1. Generates calculator and test code
2. Runs Black formatter
3. Runs isort import sorter
4. Runs Ruff linter
5. Runs pytest
6. Reports success or failure

## Documentation Updates

Added "Local Testing" section explaining:
- How to use the test script
- That long description strings in `Field()` are Black-compliant
- Example TOML specification
- Cleanup instructions

This complements the existing web-based PR submission workflow without replacing it.